### PR TITLE
Introduce Helm chart for (terrestris) mapproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# helm-charts
+# terrestris Helm Charts
+
+The helm charts of terrestris...
+
+## Prerequisites
+* Helm (package manager for Kubernetes), see also [here](https://helm.sh/)
+## Lint charts
+In order to lint charts locally, simply run:
+```bash
+helm lint charts/*
+```

--- a/charts/mapproxy/.helmignore
+++ b/charts/mapproxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mapproxy/Chart.yaml
+++ b/charts/mapproxy/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: mapproxy
+description: A Helm chart for Kubernetes
+
+icon: https://mapproxy.org/docs/nightly/_static/logo.png
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: 1.14.0

--- a/charts/mapproxy/README.md
+++ b/charts/mapproxy/README.md
@@ -1,3 +1,22 @@
 # Helm chart for mapproxy
 
-Helm chart that uses [`terrestris/mapproxy` image](https://github.com/terrestris/docker-mapproxy/)
+Helm chart that uses [`terrestris/mapproxy`](https://github.com/terrestris/docker-mapproxy/) docker image for Kubernetes cluster deployments. Beside a running instance of `terrestris/mapproxy`, a nginx is deployed to handle mapproxy's UWSGI requests. The used version of `mapproxy` can be defined in `Chart.yaml`, in particular in property `appVersion`. By default the deployed mapproxy in cluster will provide a preconfigured cache of [OWS-terrestris](https://www.terrestris.de/de/openstreetmap-wms/). 
+
+The following mapproxy specific parameters can be configured in (custom) `values.yaml`:
+* `mapproxy.uwsgiProcesses`: The number of uwsgi processes (default: 2)
+* `mapproxy.uwsgiThreads`: The number of uwsgi threads (default: 20)
+* `persistence.enabled`: A default pvc (persistant volume claim) is used for persistent mapproxy data
+* `persistence.size`: Size of pvc (persistant volume claim)
+* `persistence.useExisting`: Should an existing pvc (persistant volume claim) be used, default: `false`
+* `persistence.existingPvcName`: The name of an existing pvc (persistant volume claim) that should be used to store mapproxy data in
+
+An existing `mapproxy.yaml` can easily be provided via a further config map. In this case add / modify (custom) `values.yaml` as follows:
+```yaml
+...
+customMapproxyConfig:
+  enabled: true
+  configMapName: your-config-map
+```
+The config map itself could be created using kubectl via `kubectl create configmap your-config-map --from-file mapproxy.yaml`.
+
+Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g base cache path: `/srv/mapproxy/cache_data`)

--- a/charts/mapproxy/README.md
+++ b/charts/mapproxy/README.md
@@ -1,0 +1,3 @@
+# Helm chart for mapproxy
+
+Helm chart that uses [`terrestris/mapproxy` image](https://github.com/terrestris/docker-mapproxy/)

--- a/charts/mapproxy/templates/NOTES.txt
+++ b/charts/mapproxy/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mapproxy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mapproxy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mapproxy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mapproxy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/mapproxy/templates/_helpers.tpl
+++ b/charts/mapproxy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mapproxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mapproxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mapproxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mapproxy.labels" -}}
+helm.sh/chart: {{ include "mapproxy.chart" . }}
+{{ include "mapproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mapproxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mapproxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mapproxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mapproxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mapproxy/templates/configmap.yaml
+++ b/charts/mapproxy/templates/configmap.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mapproxy.fullname" . }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+data:
+  app.py: |-
+    # WSGI module for use with Apache mod_wsgi or gunicorn
+    import os
+    from mapproxy.wsgiapp import make_wsgi_app
+    application = make_wsgi_app(os.getenv('UWSGI_PYARGV'), reloader=True)
+  mapproxy.yaml: |-
+    # -------------------------------
+    # MapProxy configuration.
+    #
+    # OSM example based on https://wiki.openstreetmap.org/wiki/MapProxy
+    # -------------------------------
+    services:
+      demo:
+      wmts:
+        restful: true
+
+    layers:
+      - name: osm-terrestris
+        title: OpenStreetMap WMS by terrestris
+        sources: [osm_terrestris_cache]
+
+    caches:
+      osm_terrestris_cache:
+        sources: [osm_terrestris]
+        grids: [osm_terrestris_grid]
+        format: image/png
+        cache:
+          type: sqlite
+          directory: /srv/mapproxy/cache_data/osm_terrestris_cache
+
+    sources:
+      osm_terrestris:
+        type: wms
+        req:
+          url: https://ows.terrestris.de/osm/service
+          transparent: true
+          layers: OSM-WMS
+
+    grids:
+      osm_terrestris_grid:
+        srs: EPSG:3857
+        origin: nw
+
+    globals:
+      cache:
+        base_dir: '/srv/mapproxy/cache_data'
+        lock_dir: '/srv/mapproxy/cache_data/locks'
+        tile_lock_dir: '/srv/mapproxy/cache_data/tile_locks'
+
+    image:
+      resampling_method: bicubic
+  seed.yaml: |-
+    seeds:
+      osm_terrestris_cache:
+        caches: [osm_terrestris_cache]
+        refresh_before:
+          weeks: 1
+  uwsgi.conf: |-
+    [uwsgi]
+    master = true
+    chdir = $(UWSGI_CHDIR)
+    pyargv = $(UWSGI_PYARGV)
+    wsgi-file = $(UWSGI_WSGI_FILE)
+    pidfile=/tmp/mapproxy.pid
+    socket = /tmp/uwsgi.sock
+    processes = $(UWSGI_PROCESSES)
+    threads = $(UWSGI_THREADS)
+    chmod-socket = 777
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mapproxy.fullname" . }}-nginx
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+data:
+  default.conf: |-
+    server {
+        listen 80;
+
+        root /var/www/html/;
+
+        location /mapproxy/ {
+            rewrite /mapproxy/(.+) /$1 break;
+            uwsgi_param SCRIPT_NAME /mapproxy;
+            uwsgi_pass unix:///tmp/uwsgi.sock;
+            include uwsgi_params;
+        }
+    }

--- a/charts/mapproxy/templates/deployment.yaml
+++ b/charts/mapproxy/templates/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mapproxy.fullname" . }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mapproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mapproxy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mapproxy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: mapproxy
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: UWSGI_PROCESSES
+              value: "{{ .Values.mapproxy.uwsgiProcesses }}"
+            - name: UWSGI_THREADS
+              value: "{{ .Values.mapproxy.uwsgiThreads }}"
+            - name: UWSGI_CHDIR
+              value: "/srv/mapproxy/config"
+            {{- if and .Values.customMapproxyConfig.enabled }}
+            - name: UWSGI_PYARGV
+              value: "/srv/mapproxy/customconfig/mapproxy.yaml"
+            {{- else }}
+            - name: UWSGI_PYARGV
+              value: "/srv/mapproxy/config/mapproxy.yaml"
+            {{- end }}
+            - name: UWSGI_WSGI_FILE
+              value: "/srv/mapproxy/config/app.py"
+          resources:
+            {{- toYaml .Values.resources.mapproxy | nindent 12 }}
+          command: ["bash", "-c"]     
+          args: ["uwsgi --ini /srv/mapproxy/config/uwsgi.conf"]
+          volumeMounts:
+            - name: datadir
+              mountPath: /srv/mapproxy/cache_data
+            - name: mapproxy-config
+              mountPath: /srv/mapproxy/config
+            - name: socket
+              mountPath: /tmp
+            {{- if and .Values.customMapproxyConfig.enabled }}
+            - name: mapproxy-yaml
+              mountPath: /srv/mapproxy/customconfig/
+            {{- end }}
+        - name: mapproxy-nginx
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "nginx:{{ .Values.nginx.version }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /mapproxy/demo
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /mapproxy/demo
+              port: http
+          resources:
+            {{- toYaml .Values.resources.nginx | nindent 12 }}
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/
+            - name: socket
+              mountPath: /tmp
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: mapproxy-config
+          configMap:
+            name: {{ include "mapproxy.fullname" . }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "mapproxy.fullname" . }}-nginx
+        {{- if and .Values.customMapproxyConfig.enabled }}
+        - name: mapproxy-yaml
+          configMap:
+            name: {{ .Values.customMapproxyConfig.configMapName }}
+        {{- end }}
+        - name: socket
+          emptyDir: {}
+        {{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) }}
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: {{ include "mapproxy.fullname" . }}
+        {{- else if and .Values.persistence.useExisting (.Values.persistence.existingPvcName) }}
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingPvcName }}
+        {{- else }}
+        - name: datadir
+          emptyDir: {} 
+        {{- end }}

--- a/charts/mapproxy/templates/ingress.yaml
+++ b/charts/mapproxy/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mapproxy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mapproxy/templates/pvc.yaml
+++ b/charts/mapproxy/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) -}}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "mapproxy.fullname" . }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/mapproxy/templates/service.yaml
+++ b/charts/mapproxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mapproxy.fullname" . }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mapproxy.selectorLabels" . | nindent 4 }}

--- a/charts/mapproxy/templates/serviceaccount.yaml
+++ b/charts/mapproxy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mapproxy.serviceAccountName" . }}
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mapproxy/templates/tests/test-connection.yaml
+++ b/charts/mapproxy/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mapproxy.fullname" . }}-test-connection"
+  labels:
+    {{- include "mapproxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mapproxy.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/mapproxy/values.yaml
+++ b/charts/mapproxy/values.yaml
@@ -1,0 +1,106 @@
+# Default values for mapproxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: terrestris/mapproxy
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  mapproxy:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+  nginx: 
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# optional existing pvc for persistent mapproxy data
+persistence:
+  enabled: false
+  # storageClassName: default
+  accessMode: ReadWriteMany
+  size: 20Gi
+  useExisting: false
+  # existingPvcName: pvcName
+
+nginx:
+  version: latest
+
+mapproxy:
+  uwsgiProcesses: 2
+  uwsgiThreads: 16
+
+customMapproxyConfig:
+  enabled: false
+  # configMapName: configMapName


### PR DESCRIPTION
This PR introduces an initial version of an Helm chart that uses [`terrestris/mapproxy`](https://github.com/terrestris/docker-mapproxy/) docker image for Kubernetes cluster deployments. Beside a running instance of `terrestris/mapproxy`, a nginx is deployed to handle mapproxy's UWSGI requests. The used version of `mapproxy` can be defined in `Chart.yaml`, in particular in property `appVersion`. By default the deployed mapproxy in cluster will provide a preconfigured cache of [OWS-terrestris](https://www.terrestris.de/de/openstreetmap-wms/). 

The following mapproxy specific parameters can be configured in (custom) `values.yaml`:
* `mapproxy.uwsgiProcesses`: The number of uwsgi processes (default: 2)
* `mapproxy.uwsgiThreads`: The number of uwsgi threads (default: 20)
* `persistence.enabled`: A default pvc (persistant volume claim) is used for persistent mapproxy data
* `persistence.size`: Size of pvc (persistant volume claim)
* `persistence.useExisting`: Should an existing pvc (persistant volume claim) be used, default: `false`
* `persistence.existingPvcName`: The name of an existing pvc (persistant volume claim) that should be used to store mapproxy data in

An existing `mapproxy.yaml` can easily be provided via a further config map. In this case add / modify (custom) `values.yaml` as follows:
```yaml
...
customMapproxyConfig:
  enabled: true
  configMapName: your-config-map
```
The config map itself could be created using kubectl via `kubectl create configmap your-config-map --from-file mapproxy.yaml`.

Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g base cache path: `/srv/mapproxy/cache_data`)


Plz review @terrestris/devs 