### PR TITLE
allow to download printconfig which requires credentials

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,10 +2,11 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
 
-[*.{yml, yaml}]
-indent_size = 2
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false

--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for the geoserver
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 0.0.1
+version: 0.0.2
 appVersion: 2.21.2

--- a/charts/mapfish-print/Chart.yaml
+++ b/charts/mapfish-print/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mapfish-print
 description: Helm chart for MapFish Print v3
-version: 0.0.1
+version: 0.0.2
 appVersion: 3.29.3

--- a/charts/mapfish-print/README.md
+++ b/charts/mapfish-print/README.md
@@ -6,5 +6,6 @@ The following parameters can be configured in (custom) `values.yaml`:
 
 * `storage.printConfigDir`: Where to mount the print apps dir.
 * `storage.printAppsUrl`: (Optional) External link to a compressed print apps archive (.tar.gz). The data will be extracted during startup.
+    * Credentials can be provided by setting `PRINTCONFIG_USER` and `PRINTCONFIG_PASSWORD` via `extraEnv` or `extraEnvFrom`
 * `extraEnv`: Map of additional environment variables passed to mapfish print.
 * `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.

--- a/charts/mapfish-print/templates/configmap.yaml
+++ b/charts/mapfish-print/templates/configmap.yaml
@@ -7,14 +7,20 @@ metadata:
 data:
   init-printapps.sh: |-
     #!/bin/sh
+    apk add --no-cache wget
     echo "Initializing print apps"
     FILE={{ .Values.storage.printConfigDir }}/.init
     if [ -f "$FILE" ]; then
       echo "Print apps already initialized"
     else
       echo "Downloading print apps"
-      CMD="wget -q -O /mnt/download/printapps.tar.gz '{{ .Values.storage.printAppsUrl }}'"
-      echo $CMD
+      if ([ -z "$PRINTCONFIG_USER" ] || [ -z "$PRINTCONFIG_PASSWORD" ]); then
+        echo "Downloading without credentials…"
+        CMD="wget -q -O /mnt/download/printapps.tar.gz '{{ .Values.storage.printAppsUrl }}'"
+      else
+        echo "Downloading with credentials…"
+        CMD="wget --user $PRINTCONFIG_USER --password $PRINTCONFIG_PASSWORD -q -O /mnt/download/printapps.tar.gz '{{ .Values.storage.printAppsUrl }}'"
+      fi
       eval $CMD
       CMD="cd {{ .Values.storage.printConfigDir }}"
       echo $CMD

--- a/charts/mapfish-print/templates/deployment.yaml
+++ b/charts/mapfish-print/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
         - name: init-printapps
           image: alpine
           command: ["/bin/sh","/mnt/init-printapps.sh"]
+          env:
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: temp
               mountPath: /mnt/download

--- a/charts/mapfish-print/values.yaml
+++ b/charts/mapfish-print/values.yaml
@@ -59,6 +59,10 @@ probes:
 #     value: DEBUG
 #   - name: JASPER_LOG_LEVEL
 #     value: DEBUG
+#   - name: PRINTCONFIG_USER
+#     value: user
+#   - name: PRINTCONFIG_PASSWORD
+#     value: pass
 
 # extraEnvFrom: |
 #   - secretRef:


### PR DESCRIPTION
See title. Also fixes the geoserver version, which was missing in the last MR (#12).

@terrestris/devs Please review