### PR TITLE
allow more flexibility for extra env

### DIFF
--- a/charts/mapfish-print/Chart.yaml
+++ b/charts/mapfish-print/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mapfish-print
 description: Helm chart for MapFish Print v3
-version: 0.0.2
+version: 0.0.3
 appVersion: 3.29.3

--- a/charts/mapfish-print/README.md
+++ b/charts/mapfish-print/README.md
@@ -6,6 +6,8 @@ The following parameters can be configured in (custom) `values.yaml`:
 
 * `storage.printConfigDir`: Where to mount the print apps dir.
 * `storage.printAppsUrl`: (Optional) External link to a compressed print apps archive (.tar.gz). The data will be extracted during startup.
-    * Credentials can be provided by setting `PRINTCONFIG_USER` and `PRINTCONFIG_PASSWORD` via `extraEnv` or `extraEnvFrom`
+    * Credentials can be provided by setting `PRINTCONFIG_USER` and `PRINTCONFIG_PASSWORD` via `extraInitEnv` or `extraInitEnvFrom`
 * `extraEnv`: Map of additional environment variables passed to mapfish print.
 * `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
+* `extraInitEnv`: Map of additional environment variables passed to the init container.
+* `extraInitEnvFrom`: Pass additional environment variables from secrets, configmaps etc. to the init container.

--- a/charts/mapfish-print/templates/deployment.yaml
+++ b/charts/mapfish-print/templates/deployment.yaml
@@ -28,11 +28,11 @@ spec:
           image: alpine
           command: ["/bin/sh","/mnt/init-printapps.sh"]
           env:
-            {{- with .Values.extraEnv }}
+            {{- with .Values.extraInitEnv }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}
           envFrom:
-            {{- with .Values.extraEnvFrom }}
+            {{- with .Values.extraInitEnvFrom }}
             {{- tpl . $ | nindent 12 }}
             {{- end }}
           volumeMounts:

--- a/charts/mapproxy/Chart.yaml
+++ b/charts/mapproxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mapproxy/README.md
+++ b/charts/mapproxy/README.md
@@ -9,6 +9,8 @@ The following mapproxy specific parameters can be configured in (custom) `values
 * `persistence.size`: Size of pvc (persistant volume claim)
 * `persistence.useExisting`: Should an existing pvc (persistant volume claim) be used, default: `false`
 * `persistence.existingPvcName`: The name of an existing pvc (persistant volume claim) that should be used to store mapproxy data in
+* `extraEnv`: Map of additional environment variables passed to mapproxy.
+* `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
 
 An existing `mapproxy.yaml` can easily be provided via a further config map. In this case add / modify (custom) `values.yaml` as follows:
 ```yaml

--- a/charts/mapproxy/templates/deployment.yaml
+++ b/charts/mapproxy/templates/deployment.yaml
@@ -49,9 +49,16 @@ spec:
             {{- end }}
             - name: UWSGI_WSGI_FILE
               value: "/srv/mapproxy/config/app.py"
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources.mapproxy | nindent 12 }}
-          command: ["bash", "-c"]     
+          command: ["bash", "-c"]
           args: ["uwsgi --ini /srv/mapproxy/config/uwsgi.conf"]
           volumeMounts:
             - name: datadir
@@ -124,5 +131,5 @@ spec:
             claimName: {{ .Values.persistence.existingPvcName }}
         {{- else }}
         - name: datadir
-          emptyDir: {} 
+          emptyDir: {}
         {{- end }}


### PR DESCRIPTION
mapfish-print:

- adds `extraInitEnv` and `extraInitEnvFrom` which allows to configure environment variables only for the init container

mapproxy:

- introduces `extraEnv` and `extraEnvFrom`

@terrestris/devs Please review