### PR TITLE
feat: allow to initialize data directory from remote URL

### DIFF
--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "11-3.0"
 description: PostGIS Helm chart
 name: postgis
-version: 0.1.4
+version: 0.2.0
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/README.md
+++ b/charts/postgis/README.md
@@ -1,0 +1,13 @@
+# Helm chart for PostGIS
+
+Helm chart that uses the [`docker.terrestris.de/postgis/postgis`](https://docker.terrestris.de/postgis/postgis) docker image for Kubernetes cluster deployments. The PostGIS version can be defined in the `Chart.yaml` file by setting `appVersion`.
+
+The following parameters can be configured in `values.yaml`:
+
+* `postgres.customInit`: Will use `init.sql` as a custom init script. This creates the specified role and database.
+* `dataImport`: Extracts and uses the data available at `dataImport.initDataUrl` as the default data directory. CAUTION! This will overwrite existing data.
+  * Credentials can be provided by setting `DL_USER` and `DL_PASSWORD` via `extraInitEnv` or `extraInitEnvFrom`
+* `extraEnv`: Map of additional environment variables passed to PostGIS.
+* `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
+* `extraInitEnv`: Map of additional environment variables passed to the init container.
+* `extraInitEnvFrom`: Pass additional environment variables from secrets, configmaps etc. to the init container.

--- a/charts/postgis/README.md
+++ b/charts/postgis/README.md
@@ -4,9 +4,18 @@ Helm chart that uses the [`docker.terrestris.de/postgis/postgis`](https://docker
 
 The following parameters can be configured in `values.yaml`:
 
-* `postgres.customInit`: Will use `init.sql` as a custom init script. This creates the specified role and database.
-* `dataImport`: Extracts and uses the data available at `dataImport.initDataUrl` as the default data directory. CAUTION! This will overwrite existing data.
-  * Credentials can be provided by setting `DL_USER` and `DL_PASSWORD` via `extraInitEnv` or `extraInitEnvFrom`
+## Data import
+
+These options allow to set up an initial database:
+
+1. `postgres.customInit`: Will use `init.sql` as a custom init script. This creates the specified role and database.
+2. `dataImport`: Extracts and uses the data available at `dataImport.initDataUrl` as the default data directory. CAUTION! This will overwrite existing data.
+    * Credentials can be provided by setting `DL_USER` and `DL_PASSWORD` via `extraInitEnv` or `extraInitEnvFrom`
+
+Both options cannot be enabled together!
+
+## Additional configuration
+
 * `extraEnv`: Map of additional environment variables passed to PostGIS.
 * `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
 * `extraInitEnv`: Map of additional environment variables passed to the init container.

--- a/charts/postgis/templates/configmap.yaml
+++ b/charts/postgis/templates/configmap.yaml
@@ -26,17 +26,18 @@ data:
         echo "Downloading with credentials…"
         CMD="wget --user $DL_USER --password $DL_PASSWORD -q -O /mnt/download/postgresql_data.tar.gz '{{ .Values.dataImport.initDataUrl }}'"
       fi
-      echo $(du -h /var/lib/postgresql/data)
       eval $CMD
       CMD="cd {{ .Values.dataImport.dataDir }}"
       echo $CMD
       eval $CMD
-      CMD="tar -zxf /mnt/download/postgresql_data.tar.gz --strip 1 -k"
+      CMD="rm -rf {{ .Values.dataImport.dataDir }}/*"
+      echo $CMD
+      eval $CMD
+      CMD="tar -zxf /mnt/download/postgresql_data.tar.gz --strip 1 --overwrite"
       echo $CMD
       eval $CMD
       CMD="touch $FILE"
       echo $CMD
-      echo $(du -h /var/lib/postgresql/data)
       eval $CMD
       echo "Successfully extracted init data to '{{ .Values.dataImport.dataDir }}'!"
     fi

--- a/charts/postgis/templates/configmap.yaml
+++ b/charts/postgis/templates/configmap.yaml
@@ -10,3 +10,33 @@ data:
     {{- range .Values.postgres.customInit.databases }}
     CREATE DATABASE {{ . }} OWNER {{ $.Values.postgres.customInit.user }};
     {{- end }}
+  init-data.sh: |-
+    #!/bin/sh
+    apk add --no-cache wget
+    echo "Checking if postgresql data is already initialized…"
+    FILE={{ .Values.dataImport.dataDir }}/.init
+    if [ -f "$FILE" ]; then
+      echo "Data directory already initialized."
+    else
+      echo "Downloading init data…"
+      if ([ -z "$DL_USER" ] || [ -z "$DL_PASSWORD" ]); then
+        echo "Downloading without credentials…"
+        CMD="wget -q -O /mnt/download/postgresql_data.tar.gz '{{ .Values.dataImport.initDataUrl }}'"
+      else
+        echo "Downloading with credentials…"
+        CMD="wget --user $DL_USER --password $DL_PASSWORD -q -O /mnt/download/postgresql_data.tar.gz '{{ .Values.dataImport.initDataUrl }}'"
+      fi
+      echo $(du -h /var/lib/postgresql/data)
+      eval $CMD
+      CMD="cd {{ .Values.dataImport.dataDir }}"
+      echo $CMD
+      eval $CMD
+      CMD="tar -zxf /mnt/download/postgresql_data.tar.gz --strip 1 -k"
+      echo $CMD
+      eval $CMD
+      CMD="touch $FILE"
+      echo $CMD
+      echo $(du -h /var/lib/postgresql/data)
+      eval $CMD
+      echo "Successfully extracted init data to '{{ .Values.dataImport.dataDir }}'!"
+    fi

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -39,8 +39,9 @@ spec:
               mountPath: /mnt/download
             - name: init-configmap
               mountPath: /mnt/
-            - name: postgresql-data-dir
+            - name: data
               mountPath: {{ .Values.dataImport.dataDir }}
+              subPath: data
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -87,8 +88,6 @@ spec:
             items:
               - key: init-data.sh
                 path: init-data.sh
-        - name: postgresql-data-dir
-          emptyDir: {}
         - name: temp
           emptyDir: {}
         {{- end }}

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -21,6 +21,27 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- if and .Values.dataImport.enabled }}
+        - name: init-data
+          image: alpine
+          command: ["/bin/sh","/mnt/init-data.sh"]
+          env:
+            {{- with .Values.extraInitEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.extraInitEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: temp
+              mountPath: /mnt/download
+            - name: init-configmap
+              mountPath: /mnt/
+            - name: postgresql-data-dir
+              mountPath: {{ .Values.dataImport.dataDir }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -58,15 +79,27 @@ spec:
           - name: init
             mountPath: /docker-entrypoint-initdb.d/
           {{- end }}
-      {{- if .Values.postgres.customInit.enabled }}
       volumes:
+        {{- if .Values.dataImport.enabled }}
+        - name: init-configmap
+          configMap:
+            name: {{ include "postgis.fullname" . }}
+            items:
+              - key: init-data.sh
+                path: init-data.sh
+        - name: postgresql-data-dir
+          emptyDir: {}
+        - name: temp
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.postgres.customInit.enabled }}
         - name: init
           configMap:
             name: {{ include "postgis.fullname" . }}
             items:
               - key: init.sql
                 path: init.sql
-      {{- end }}
+        {{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/postgis/values.yaml
+++ b/charts/postgis/values.yaml
@@ -43,3 +43,12 @@ postgres:
 
 persistence:
   size: 8Gi
+
+dataImport:
+  enabled: false
+  # dataDir: /var/lib/postgresql/data
+  # initDataUrl: https://files.example.com/postgresql_data.tar.gz
+
+# extraInitEnvFrom: |
+#   - secretRef:
+#       name: initdatacred


### PR DESCRIPTION
Introduces new config `dataImport` which allows to download and extract a remove archive. This will overwrite the existing data directory.

@terrestris/devs Please review