### PR TITLE
feat: add configuration options for probes

### DIFF
--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "11-3.0"
 description: PostGIS Helm chart
 name: postgis
-version: 0.2.3
+version: 0.2.4
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
               command:
               - sh
               - -c
-              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
+              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432 -t "{{ .Values.livenessProbe.timeoutSeconds }}"
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- end }}
@@ -72,7 +72,7 @@ spec:
               command:
               - sh
               - -c
-              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
+              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432 -t "{{ .Values.livenessProbe.timeoutSeconds }}"
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- end }}
@@ -82,7 +82,7 @@ spec:
               command:
               - sh
               - -c
-              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
+              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432 -t "{{ .Values.livenessProbe.timeoutSeconds }}"
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -56,20 +56,38 @@ spec:
               value: "{{ .Values.postgres.user }}"
             - name: POSTGRES_DB
               value: "{{ .Values.postgres.db }}"
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
               - sh
               - -c
               - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
-            timeoutSeconds: 3 # setting to default timeout of pg_isready
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command:
               - sh
               - -c
               - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
-            timeoutSeconds: 3 # setting to default timeout of pg_isready
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - exec pg_isready -U "{{ .Values.postgres.user }}" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/postgis/values.yaml
+++ b/charts/postgis/values.yaml
@@ -52,3 +52,20 @@ dataImport:
 # extraInitEnvFrom: |
 #   - secretRef:
 #       name: initdatacred
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 3 # default timeout of pg_isready
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  timeoutSeconds: 3 # default timeout of pg_isready
+
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 60
+  timeoutSeconds: 1
+  failureThreshold: 15
+  periodSeconds: 5


### PR DESCRIPTION
Allows to configure `livenessProbe`, `readinessProbe` and `startupProbe` options.

@terrestris/devs Please review