### PR TITLE
Make seed.yaml configurable via configmap

### DIFF
--- a/charts/mapproxy/Chart.yaml
+++ b/charts/mapproxy/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mapproxy/README.md
+++ b/charts/mapproxy/README.md
@@ -5,10 +5,10 @@ Helm chart that uses [`terrestris/mapproxy`](https://github.com/terrestris/docke
 The following mapproxy specific parameters can be configured in (custom) `values.yaml`:
 * `mapproxy.uwsgiProcesses`: The number of uwsgi processes (default: 2)
 * `mapproxy.uwsgiThreads`: The number of uwsgi threads (default: 20)
-* `persistence.enabled`: A default pvc (persistant volume claim) is used for persistent mapproxy data
-* `persistence.size`: Size of pvc (persistant volume claim)
-* `persistence.useExisting`: Should an existing pvc (persistant volume claim) be used, default: `false`
-* `persistence.existingPvcName`: The name of an existing pvc (persistant volume claim) that should be used to store mapproxy data in
+* `persistence.enabled`: A default pvc (persistent volume claim) is used for persistent mapproxy data
+* `persistence.size`: Size of pvc (persistent volume claim)
+* `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
+* `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store mapproxy data in
 * `extraEnv`: Map of additional environment variables passed to mapproxy.
 * `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
 
@@ -21,4 +21,12 @@ customMapproxyConfig:
 ```
 The config map itself could be created using kubectl via `kubectl create configmap your-config-map --from-file mapproxy.yaml`.
 
-Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g base cache path: `/srv/mapproxy/cache_data`)
+Similarly, for the `seed.yaml` the configuration can be loaded from a configmap (e.g. `your-seed-config-map`) as well:
+```yaml
+...
+customSeedConfig:
+  enabled: true
+  configMapName: your-seed-config-map
+```
+
+Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g. base cache path: `/srv/mapproxy/cache_data`)

--- a/charts/mapproxy/templates/deployment.yaml
+++ b/charts/mapproxy/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: mapproxy-yaml
               mountPath: /srv/mapproxy/customconfig/
             {{- end }}
-            {{- if and .Values.customSeedConfig.enabled }}
+            {{- if .Values.customSeedConfig.enabled }}
             - name: seed-yaml
               mountPath: /srv/mapproxy/customconfig/
             {{- end }}

--- a/charts/mapproxy/templates/deployment.yaml
+++ b/charts/mapproxy/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
           configMap:
             name: {{ .Values.customMapproxyConfig.configMapName }}
         {{- end }}
-        {{- if and .Values.customSeedConfig.enabled }}
+        {{- if .Values.customSeedConfig.enabled }}
         - name: seed-yaml
           configMap:
             name: {{ .Values.customSeedConfig.configMapName }}

--- a/charts/mapproxy/templates/deployment.yaml
+++ b/charts/mapproxy/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
             - name: mapproxy-yaml
               mountPath: /srv/mapproxy/customconfig/
             {{- end }}
+            {{- if and .Values.customSeedConfig.enabled }}
+            - name: seed-yaml
+              mountPath: /srv/mapproxy/customconfig/
+            {{- end }}
         - name: mapproxy-nginx
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -118,6 +122,11 @@ spec:
         - name: mapproxy-yaml
           configMap:
             name: {{ .Values.customMapproxyConfig.configMapName }}
+        {{- end }}
+        {{- if and .Values.customSeedConfig.enabled }}
+        - name: seed-yaml
+          configMap:
+            name: {{ .Values.customSeedConfig.configMapName }}
         {{- end }}
         - name: socket
           emptyDir: {}

--- a/charts/mapproxy/values.yaml
+++ b/charts/mapproxy/values.yaml
@@ -103,7 +103,11 @@ mapproxy:
 
 customMapproxyConfig:
   enabled: false
-  # configMapName: configMapName
+  configMapName: ""
+
+customSeedConfig:
+  enabled: false
+  configMapName: ""
 
 probes:
   livenessUrl: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml


### PR DESCRIPTION
Similar to the configuration of `mapproxy.yaml`, this PR introduces the configuration of the `seed.yaml` via a configmap (e.g. `your-seed-config-map`):
```yaml
...
customSeedConfig:
  enabled: true
  configMapName: your-seed-config-map
```
