### PR TITLE
version 1.0.0 releases

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for the geoserver
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 0.0.4
+version: 1.0.0
 appVersion: 2.22.2

--- a/charts/mapfish-print/Chart.yaml
+++ b/charts/mapfish-print/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: mapfish-print
 description: Helm chart for MapFish Print v3
-version: 0.0.3
+version: 1.0.0
 appVersion: 3.29.3

--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "11-3.0"
+appVersion: "15-3.3-alpine"
 description: PostGIS Helm chart
 name: postgis
-version: 0.2.5
+version: 1.0.0
 icon: https://postgis.net/logos/postgis-logo.png


### PR DESCRIPTION
Follow-up of https://github.com/terrestris/helm-charts/pull/23:

- releases version 1.0.0 for geoserver, mapfish-print and postgis
- also updates the postgis image to the `15-3.3-alpine`

@terrestris/devs Please review