### PR TITLE
feat: make pvc and storage class more configurable

### DIFF
--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "15-3.3-alpine"
 description: PostGIS Helm chart
 name: postgis
-version: 1.0.1
+version: 1.1.0
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "15-3.3-alpine"
 description: PostGIS Helm chart
 name: postgis
-version: 1.0.0
+version: 1.0.1
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/templates/pvc.yaml
+++ b/charts/postgis/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) -}}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "postgis.fullname" . }}
+  labels:
+    {{- include "postgis.labels" . | nindent 4 }}
+spec:
+  {{- if and .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -136,11 +136,11 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -91,7 +91,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          - name: data
+          - name: datadir
             mountPath: /var/lib/postgresql/data
             subPath: data
           {{- if or .Values.postgres.customInit.enabled }}

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -120,15 +120,18 @@ spec:
               - key: init.sql
                 path: init.sql
         {{- end }}
-  volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - "ReadWriteOnce"
-        resources:
-          requests:
-            storage: {{ .Values.persistence.size | quote }}
+        {{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) }}
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: {{ include "postgis.fullname" . }}
+        {{- else if and .Values.persistence.useExisting (.Values.persistence.existingPvcName) }}
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingPvcName }}
+        {{- else }}
+        - name: datadir
+          emptyDir: { }
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/postgis/values.yaml
+++ b/charts/postgis/values.yaml
@@ -44,6 +44,8 @@ postgres:
 
 persistence:
   size: 8Gi
+  accessMode: ReadWriteOnce
+  storageClassName: ""
 
 dataImport:
   enabled: false

--- a/charts/postgis/values.yaml
+++ b/charts/postgis/values.yaml
@@ -43,6 +43,9 @@ postgres:
 #      - my_database
 
 persistence:
+  enabled: false
+  useExisting: false
+  existingPvcName: ""
   size: 8Gi
   accessMode: ReadWriteOnce
   storageClassName: ""


### PR DESCRIPTION
By this PR, the defintion of the `PersistantVolumeClaim` for `postgis` is externalized and made more configurable (e.g. the `StorageClass`).

Plz review @terrestris/devs  