### PR TITLE
Use official mapproxy-nginx image in helm chart and fix resources

### DIFF
--- a/charts/mapproxy/Chart.yaml
+++ b/charts/mapproxy/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.16.0
+appVersion: 1.16.0-nginx

--- a/charts/mapproxy/README.md
+++ b/charts/mapproxy/README.md
@@ -1,16 +1,14 @@
 # Helm chart for mapproxy
 
-Helm chart that uses [`terrestris/mapproxy`](https://github.com/terrestris/docker-mapproxy/) docker image for Kubernetes cluster deployments. Beside a running instance of `terrestris/mapproxy`, a nginx is deployed to handle mapproxy's UWSGI requests. The used version of `mapproxy` can be defined in `Chart.yaml`, in particular in property `appVersion`. By default the deployed mapproxy in cluster will provide a preconfigured cache of [OWS-terrestris](https://www.terrestris.de/de/openstreetmap-wms/). 
+Helm chart that uses the official [`mapproxy` docker image](https://github.com/mapproxy/mapproxy/pkgs/container/mapproxy%2Fmapproxy) for Kubernetes cluster deployments.
+The used version of `mapproxy` can be defined in `Chart.yaml`, in particular in property `appVersion`.
+By default, the deployed mapproxy in cluster will provide a preconfigured cache of [OWS-terrestris](https://www.terrestris.de/de/openstreetmap-wms/). 
 
 The following mapproxy specific parameters can be configured in (custom) `values.yaml`:
-* `mapproxy.uwsgiProcesses`: The number of uwsgi processes (default: 2)
-* `mapproxy.uwsgiThreads`: The number of uwsgi threads (default: 20)
 * `persistence.enabled`: A default pvc (persistent volume claim) is used for persistent mapproxy data
 * `persistence.size`: Size of pvc (persistent volume claim)
 * `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
 * `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store mapproxy data in
-* `extraEnv`: Map of additional environment variables passed to mapproxy.
-* `extraEnvFrom`: Pass additional environment variables from secrets, configmaps etc.
 
 An existing `mapproxy.yaml` can easily be provided via a further config map. In this case add / modify (custom) `values.yaml` as follows:
 ```yaml
@@ -29,4 +27,4 @@ customSeedConfig:
   configMapName: your-seed-config-map
 ```
 
-Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g. base cache path: `/srv/mapproxy/cache_data`)
+Please note that cache paths (only if configured) have to match the ones configured in `volume` block (e.g. base cache path: `/mapproxy/config/cache_data`)

--- a/charts/mapproxy/templates/configmap.yaml
+++ b/charts/mapproxy/templates/configmap.yaml
@@ -5,11 +5,6 @@ metadata:
   labels:
     {{- include "mapproxy.labels" . | nindent 4 }}
 data:
-  app.py: |-
-    # WSGI module for use with Apache mod_wsgi or gunicorn
-    import os
-    from mapproxy.wsgiapp import make_wsgi_app
-    application = make_wsgi_app(os.getenv('UWSGI_PYARGV'), reloader=True)
   mapproxy.yaml: |-
     # -------------------------------
     # MapProxy configuration.
@@ -17,8 +12,10 @@ data:
     # OSM example based on https://wiki.openstreetmap.org/wiki/MapProxy
     # -------------------------------
     services:
+      demo:
       wmts:
-        restful: true
+      wms:
+        srs: ['EPSG:3857']
 
     layers:
       - name: osm-terrestris
@@ -32,7 +29,7 @@ data:
         format: image/png
         cache:
           type: sqlite
-          directory: /srv/mapproxy/cache_data/osm_terrestris_cache
+          directory: /mapproxy/config/cache_data/osm_terrestris_cache
 
     sources:
       osm_terrestris:
@@ -49,10 +46,9 @@ data:
 
     globals:
       cache:
-        base_dir: '/srv/mapproxy/cache_data'
-        lock_dir: '/srv/mapproxy/cache_data/locks'
-        tile_lock_dir: '/srv/mapproxy/cache_data/tile_locks'
-
+        base_dir: '/mapproxy/config/cache_data'
+        lock_dir: '/mapproxy/config/cache_data/locks'
+        tile_lock_dir: '/mapproxy/config/cache_data/tile_locks'
     image:
       resampling_method: bicubic
   seed.yaml: |-
@@ -61,35 +57,3 @@ data:
         caches: [osm_terrestris_cache]
         refresh_before:
           weeks: 1
-  uwsgi.conf: |-
-    [uwsgi]
-    master = true
-    chdir = $(UWSGI_CHDIR)
-    pyargv = $(UWSGI_PYARGV)
-    wsgi-file = $(UWSGI_WSGI_FILE)
-    pidfile=/tmp/mapproxy.pid
-    socket = /tmp/uwsgi.sock
-    processes = $(UWSGI_PROCESSES)
-    threads = $(UWSGI_THREADS)
-    chmod-socket = 777
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "mapproxy.fullname" . }}-nginx
-  labels:
-    {{- include "mapproxy.labels" . | nindent 4 }}
-data:
-  default.conf: |-
-    server {
-        listen 80;
-
-        root /var/www/html/;
-
-        location /mapproxy/ {
-            rewrite /mapproxy/(.+) /$1 break;
-            uwsgi_param SCRIPT_NAME /mapproxy;
-            uwsgi_pass unix:///tmp/uwsgi.sock;
-            include uwsgi_params;
-        }
-    }

--- a/charts/mapproxy/templates/pvc.yaml
+++ b/charts/mapproxy/templates/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "mapproxy.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.persistence.storageClassName }}
+  {{- with .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName }}
   {{- end }}
   accessModes:

--- a/charts/mapproxy/templates/statefulset.yaml
+++ b/charts/mapproxy/templates/statefulset.yaml
@@ -34,72 +34,55 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: UWSGI_PROCESSES
-              value: "{{ .Values.mapproxy.uwsgiProcesses }}"
-            - name: UWSGI_THREADS
-              value: "{{ .Values.mapproxy.uwsgiThreads }}"
-            - name: UWSGI_CHDIR
-              value: "/srv/mapproxy/config"
-            {{- if and .Values.customMapproxyConfig.enabled }}
-            - name: UWSGI_PYARGV
-              value: "/srv/mapproxy/customconfig/mapproxy.yaml"
-            {{- else }}
-            - name: UWSGI_PYARGV
-              value: "/srv/mapproxy/config/mapproxy.yaml"
-            {{- end }}
-            - name: UWSGI_WSGI_FILE
-              value: "/srv/mapproxy/config/app.py"
-            {{- with .Values.extraEnv }}
-            {{- tpl . $ | nindent 12 }}
-            {{- end }}
-          envFrom:
-            {{- with .Values.extraEnvFrom }}
-            {{- tpl . $ | nindent 12 }}
-            {{- end }}
           resources:
-            {{- toYaml .Values.resources.mapproxy | nindent 12 }}
-          command: ["bash", "-c"]
-          args: ["uwsgi --ini /srv/mapproxy/config/uwsgi.conf"]
-          volumeMounts:
-            - name: datadir
-              mountPath: /srv/mapproxy/cache_data
-            - name: mapproxy-config
-              mountPath: /srv/mapproxy/config
-            - name: socket
-              mountPath: /tmp
-            {{- if and .Values.customMapproxyConfig.enabled }}
-            - name: mapproxy-yaml
-              mountPath: /srv/mapproxy/customconfig/
-            {{- end }}
-            {{- if and .Values.customSeedConfig.enabled }}
-            - name: seed-yaml
-              mountPath: /srv/mapproxy/customseedconfig/
-            {{- end }}
-        - name: mapproxy-nginx
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "nginx:{{ .Values.nginx.version }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 80
-              protocol: TCP
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probes.livenessUrl }}
+              path: {{ .Values.livenessProbe.url }}
               port: http
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probes.readinessUrl }}
+              path: {{ .Values.readinessProbe.url }}
               port: http
-          resources:
-            {{- toYaml .Values.resources.nginx | nindent 12 }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.url }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           volumeMounts:
-            - name: nginx-config
-              mountPath: /etc/nginx/conf.d/
-            - name: socket
-              mountPath: /tmp
+            - name: cache-datadir
+              mountPath: /mapproxy/config/cache_data/
+            {{- if and .Values.customMapproxyConfig.enabled }}
+            - name: custom-mapproxy-yaml
+              mountPath: /mapproxy/config/mapproxy.yaml
+              subPath: mapproxy.yaml
+            {{- else }}
+            - name: {{ include "mapproxy.fullname" . }}-mapproxy-yaml
+              mountPath: /mapproxy/config/mapproxy.yaml
+              subPath: mapproxy.yaml
+            {{- end }}
+            {{- if and .Values.customSeedConfig.enabled }}
+            - name: custom-seed-yaml
+              mountPath: /mapproxy/config/seed.yaml
+              subPath: seed.yaml
+            {{- else }}
+            - name: {{ include "mapproxy.fullname" . }}-seed-yaml
+              mountPath: /mapproxy/config/seed.yaml
+              subPath: mapproxy.yaml
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -113,33 +96,33 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        - name: mapproxy-config
-          configMap:
-            name: {{ include "mapproxy.fullname" . }}
-        - name: nginx-config
-          configMap:
-            name: {{ include "mapproxy.fullname" . }}-nginx
         {{- if and .Values.customMapproxyConfig.enabled }}
-        - name: mapproxy-yaml
+        - name: custom-mapproxy-yaml
           configMap:
             name: {{ .Values.customMapproxyConfig.configMapName }}
+        {{- else}}
+        - name: {{ include "mapproxy.fullname" . }}-mapproxy-yaml
+          configMap:
+            name: {{ include "mapproxy.fullname" . }}
         {{- end }}
         {{- if .Values.customSeedConfig.enabled }}
-        - name: seed-yaml
+        - name: custom-seed-yaml
           configMap:
             name: {{ .Values.customSeedConfig.configMapName }}
+        {{- else}}
+        - name: {{ include "mapproxy.fullname" . }}-seed-yaml
+          configMap:
+            name: {{ include "mapproxy.fullname" . }}
         {{- end }}
-        - name: socket
-          emptyDir: {}
         {{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) }}
-        - name: datadir
+        - name: cache-datadir
           persistentVolumeClaim:
             claimName: {{ include "mapproxy.fullname" . }}
         {{- else if and .Values.persistence.useExisting (.Values.persistence.existingPvcName) }}
-        - name: datadir
+        - name: cache-datadir
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingPvcName }}
         {{- else }}
-        - name: datadir
+        - name: cache-datadir
           emptyDir: {}
         {{- end }}

--- a/charts/mapproxy/values.yaml
+++ b/charts/mapproxy/values.yaml
@@ -57,20 +57,12 @@ ingress:
   #      - chart-example.local
 
 resources:
-  mapproxy:
-    limits:
-      cpu: 1000m
-      memory: 1Gi
-    requests:
-      cpu: 500m
-      memory: 512Mi
-  nginx:
-    limits:
-      cpu: 250m
-      memory: 256Mi
-    requests:
-      cpu: 250m
-      memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 1500Mi
+  requests:
+    cpu: 250m
+    memory: 512Mi
 
 autoscaling:
   enabled: false
@@ -85,6 +77,28 @@ tolerations: []
 
 affinity: {}
 
+# Probes
+livenessProbe:
+  enabled: true
+  url: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml
+  initialDelaySeconds: 15
+  timeoutSeconds: 3
+  periodSeconds: 30
+  failureThreshold: 5
+
+readinessProbe:
+  enabled: true
+  url: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+
+startupProbe:
+  enabled: true
+  url: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml
+  failureThreshold: 15
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
 # optional existing pvc for persistent mapproxy data
 persistence:
   enabled: false
@@ -94,21 +108,10 @@ persistence:
   useExisting: false
   existingPvcName: ""
 
-nginx:
-  version: latest
-
-mapproxy:
-  uwsgiProcesses: 2
-  uwsgiThreads: 16
-
 customMapproxyConfig:
   enabled: false
-  configMapName: ""
+  configMapName: custom-mapproxy-yaml
 
 customSeedConfig:
   enabled: false
-  configMapName: ""
-
-probes:
-  livenessUrl: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml
-  readinessUrl: /mapproxy/wmts/1.0.0/WMTSCapabilities.xml
+  configMapName: custom-seed-yaml

--- a/charts/mapproxy/values.yaml
+++ b/charts/mapproxy/values.yaml
@@ -103,8 +103,8 @@ startupProbe:
 persistence:
   enabled: false
   storageClassName: ""
-  accessMode: ReadWriteMany
-  size: 20Gi
+  accessMode: ReadWriteOnce
+  size: 5Gi
   useExisting: false
   existingPvcName: ""
 


### PR DESCRIPTION
Since the official mapproxy repository provides an image containing a pre-configured nginx, the one in the actual helm chart can be omitted.
In addition, the resources have been fixed (e.g. paths to configs / mounts) in order to match the configs in the official [`mapproxy` docker image](https://github.com/mapproxy/mapproxy/pkgs/container/mapproxy%2Fmapproxy) and the persistent volume claim definition uses storage class only if set.

Plz review @terrestris/devs 
