### PR TITLE
Finalize GNOS helm chart

### DIFF
--- a/charts/gnos/Chart.yaml
+++ b/charts/gnos/Chart.yaml
@@ -1,24 +1,6 @@
 apiVersion: v2
-name: gnos
-description: A GNOS Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: 4.2.5
+description: A GNOS Helm chart for Kubernetes
+name: gnos
+type: application
+version: 0.1.0

--- a/charts/gnos/README.md
+++ b/charts/gnos/README.md
@@ -1,0 +1,44 @@
+# Helm Chart for Geonetwork OpenSource
+
+## Prerequisites
+
+1. Install custom resource definitions for elasticsearch
+
+```shell
+kubectl create -f https://download.elastic.co/downloads/eck/2.9.0/crds.yaml
+```
+
+2. Install the elasticsearch operator with its RBAC rules:
+
+```shell
+kubectl apply -f https://download.elastic.co/downloads/eck/2.9.0/operator.yaml
+```
+
+see here https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html#k8s-deploy-eck
+
+## Configuration
+
+This directory contains a helm chart using the official [Geonetwork OpenSource (GNOS)](https://github.com/geonetwork/docker-geonetwork) docker image for Kubernetes cluster deployments.
+Since GNOS requires a running instance of ElasticSearch (and Kibana) this is included using custom resources and corresponding configuration files.
+The GNOS version can be defined in the `Chart.yaml` file by setting `appVersion`.
+
+The following parameters can be configured in (a custom) `values.yaml`, including the version of ElasticSearch (currently only successfully tested with version 7.1.1):
+
+* `elk.version`: The version of the ELK-stack (currently 7.1.1)
+* `elk.name`: The base name of the elk-services - default: `gnos-elk`
+* `javaHeapSizeDefinition`: The Java heap size definitions - default `-Xms512M -Xss512M -Xmx2G`; Other environment variables can be placed here as well 
+* `persistence.enabled`: A default pvc (persistent volume claim) is used for persistent geoserver data
+* `persistence.size`: Size of pvc (persistent volume claim)
+* `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
+* `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store geoserver data
+* `persistence.storageClassName`: The name of the storage class to use. Leave empty if the cluster default should be used
+
+By default, it is assumed that a PostgreSQL database (name: `gnos`) exists and can be accessed by the cluster. It can be configured in `values.yaml` by:
+```yaml
+db:
+  name: gnos
+  username: postgres
+  password: postgres
+  host: postgres
+  port: 5432
+```

--- a/charts/gnos/templates/configmap.yaml
+++ b/charts/gnos/templates/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "gnos.fullname" . }}
+  labels:
+{{ include "gnos.labels" . | indent 4 }}
+data:
+  jdbc.properties: |-
+    jdbc.username={{ .Values.db.username }}
+    jdbc.password={{ .Values.db.password }}
+    jdbc.database={{ .Values.db.name }}
+    jdbc.host={{ .Values.db.host }}
+    jdbc.port={{ .Values.db.port }}
+    jdbc.connectionProperties=#{systemEnvironment['GEONETWORK_DB_CONNECTION_PROPERTIES']}
+    jdbc.basic.removeAbandoned=true
+    jdbc.basic.removeAbandonedTimeout=300
+    jdbc.basic.logAbandoned=true
+    jdbc.basic.maxActive=30
+    jdbc.basic.maxIdle=10
+    jdbc.basic.initialSize=10
+    jdbc.basic.maxWait=500
+    jdbc.basic.testOnBorrow=true
+    jdbc.basic.timeBetweenEvictionRunsMillis=1000
+    jdbc.basic.minEvictableIdleTimeMillis=1800000
+    jdbc.basic.testWhileIdle=true
+    jdbc.basic.numTestsPerEvictionRun=5
+    jdbc.basic.poolPreparedStatements=true
+    jdbc.basic.maxOpenPreparedStatements=1200
+    jdbc.basic.validationQuery=SELECT 1
+    jdbc.basic.defaultReadOnly=false
+    jdbc.basic.defaultAutoCommit=false

--- a/charts/gnos/templates/deployment.yaml
+++ b/charts/gnos/templates/deployment.yaml
@@ -37,34 +37,52 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.livenessProbe.url }}
               port: http
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.readinessProbe.url }}
               port: http
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.url }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: JAVA_OPTS
-              value: |
-                -Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF
-                -Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true
-                -Xms512M -Xss512M -Xmx2G -XX:+UseConcMarkSweepGC
-                -Dgeonetwork.resources.dir=/var/lib/geonetwork_data/resources
-                -Dgeonetwork.data.dir=/var/lib/geonetwork_data
-                -Dgeonetwork.codeList.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/codelist
-                -Dgeonetwork.schema.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/schema_plugins
-                -Dgeonetwork.db.type=postgres
-                -Djdbc.database={{ .Values.db.name }}
-                -Djdbc.username={{ .Values.db.username }}
-                -Djdbc.password={{ .Values.db.password }}
-                -Djdbc.host={{ .Values.db.host }}
-                -Djdbc.port={{ .Values.db.port }}
-            - name: ELASTICSEARCH_HOSTS
-              value: "[\"http://gnos-es-http:9200\"]"
+              value: "-Dorg.eclipse.jetty.annotations.AnnotationParser.LEVEL=OFF -Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true {{ .Values.javaHeapSizeDefinition }} -XX:+UseConcMarkSweepGC -Dgeonetwork.resources.dir=/var/lib/geonetwork_data/resources -Dgeonetwork.data.dir=/var/lib/geonetwork_data -Dgeonetwork.codeList.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/codelist -Dgeonetwork.schema.dir=/var/lib/jetty/webapps/geonetwork/WEB-INF/data/config/schema_plugins -Dgeonetwork.db.type=postgres"
+            - name: ES_HOST
+              value: {{ .Values.elk.name }}-es-http
+            - name: ES_USERNAME
+              value: "elastic"
+            - name: ES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.elk.name }}-es-elastic-user
+                  key: elastic
+            - name: ES_PROTOCOL
+              value: http
+            - name: ES_PORT
+              value: "9200"
+            - name: KB_HOST
+              value: {{ .Values.elk.name }}-kibana-kb-http
             - name: SERVER_NAME
               value: gnos-kb-http
             - name: KIBANA_INDEX
@@ -72,11 +90,14 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/geonetwork_data/
+            - name: jdbc-properties
+              mountPath: /var/lib/jetty/webapps/geonetwork/WEB-INF/config-db/jdbc.properties
+              subPath: jdbc.properties
       volumes:
         {{- if and .Values.persistence.enabled (not .Values.persistence.useExisting) }}
         - name: datadir
           persistentVolumeClaim:
-            claimName: {{ include "geoserver.fullname" . }}
+            claimName: {{ include "gnos.fullname" . }}
         {{- else if and .Values.persistence.useExisting (.Values.persistence.existingPvcName) }}
         - name: datadir
           persistentVolumeClaim:
@@ -85,6 +106,12 @@ spec:
         - name: datadir
           emptyDir: {}
         {{- end }}
+        - name: jdbc-properties
+          configMap:
+            name: {{ include "gnos.fullname" . }}
+            items:
+              - key: jdbc.properties
+                path: jdbc.properties
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/gnos/templates/elasticsearch.yaml
+++ b/charts/gnos/templates/elasticsearch.yaml
@@ -1,11 +1,15 @@
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch
 metadata:
-  name: gnos
+  name: {{ .Values.elk.name }}
 spec:
-  version: 8.9.1
+  version: {{ .Values.elk.version }}
   nodeSets:
-  - name: default
-    count: 1
-    config:
-      node.store.allow_mmap: false
+    - name: default
+      count: 1
+      config:
+        node.store.allow_mmap: false
+  http:
+    tls:
+      selfSignedCertificate:
+        disabled: true

--- a/charts/gnos/templates/kibana.yaml
+++ b/charts/gnos/templates/kibana.yaml
@@ -1,9 +1,9 @@
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana
 metadata:
-  name: gnos
+  name: {{ .Values.elk.name }}-kibana
 spec:
-  version: 8.9.1
+  version: {{ .Values.elk.version }}
   count: 1
   elasticsearchRef:
-    name: gnos
+    name: {{ .Values.elk.name }}

--- a/charts/gnos/values.yaml
+++ b/charts/gnos/values.yaml
@@ -81,6 +81,8 @@ tolerations: []
 
 affinity: {}
 
+javaHeapSizeDefinition: -Xms512M -Xss512M -Xmx2G
+
 db:
   name: gnos
   username: postgres
@@ -91,7 +93,33 @@ db:
 persistence:
   enabled: false
   useExisting: false
-  existingPvcName: ""
-  storageClassName: ""
+  existingPvcName:
+  storageClassName:
   accessMode: ReadWriteOnce
   size: 8Gi
+
+# Probes
+livenessProbe:
+  enabled: true
+  url: /geonetwork/srv/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetCapabilities
+  initialDelaySeconds: 15
+  timeoutSeconds: 3
+  periodSeconds: 30
+  failureThreshold: 5
+
+readinessProbe:
+  enabled: true
+  url: /geonetwork/srv/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetCapabilities
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+
+startupProbe:
+  enabled: true
+  url: /geonetwork/srv/eng/csw?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetCapabilities
+  failureThreshold: 15
+  initialDelaySeconds: 2
+  periodSeconds: 10
+
+elk:
+  name: gnos-elk
+  version: 7.1.1


### PR DESCRIPTION
# Helm Chart for Geonetwork OpenSource

## Prerequisites

1. Install custom resource definitions for elasticsearch

```shell
kubectl create -f https://download.elastic.co/downloads/eck/2.9.0/crds.yaml
```

2. Install the elasticsearch operator with its RBAC rules:

```shell
kubectl apply -f https://download.elastic.co/downloads/eck/2.9.0/operator.yaml
```

see here https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html#k8s-deploy-eck

## Configuration

This directory contains a helm chart using the official [Geonetwork OpenSource (GNOS)](https://github.com/geonetwork/docker-geonetwork) docker image for Kubernetes cluster deployments.
Since GNOS requires a running instance of ElasticSearch (and Kibana) this is included using custom resources and corresponding configuration files.
The GNOS version can be defined in the `Chart.yaml` file by setting `appVersion`.

The following parameters can be configured in (a custom) `values.yaml`, including the version of ElasticSearch (currently only successfully tested with version 7.1.1):

* `elk.version`: The version of the ELK-stack (currently 7.1.1)
* `elk.name`: The base name of the elk-services - default: `gnos-elk`
* `javaHeapSizeDefinition`: The Java heap size definitions - default `-Xms512M -Xss512M -Xmx2G`; Other environment variables can be placed here as well 
* `persistence.enabled`: A default pvc (persistent volume claim) is used for persistent geoserver data
* `persistence.size`: Size of pvc (persistent volume claim)
* `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
* `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store geoserver data
* `persistence.storageClassName`: The name of the storage class to use. Leave empty if the cluster default should be used

By default, it is assumed that a PostgreSQL database (name: `gnos`) exists and can be accessed by the cluster. It can be configured in `values.yaml` by:
```yaml
db:
  name: gnos
  username: postgres
  password: postgres
  host: postgres
  port: 5432
```
