### PR TITLE
Use latest gh action versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,17 +21,17 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs . --all --validate-maintainers=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@v1.8.0
 
       - name: Run chart-testing (install)
         run: ct install --chart-dirs . --all


### PR DESCRIPTION
There are problems with the current gh action pipelines due to outdated versions (see [here](https://github.com/terrestris/helm-charts/pull/43)). This PR will fix it!