### PR TITLE
Add missing "args"

### DIFF
--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "15-3.3-alpine"
 description: PostGIS Helm chart
 name: postgis
-version: 1.2.0
+version: 1.2.1
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/templates/statefulset.yaml
+++ b/charts/postgis/templates/statefulset.yaml
@@ -49,6 +49,9 @@ spec:
             - containerPort: 5432
               name: postgres
               protocol: TCP
+          {{- if .Values.postgres.conf }}
+          args: ["-c", "config_file=/etc/postgresql/postgresql.conf"]
+          {{- end }}
           env:
             - name: POSTGRES_PASSWORD
               value: "{{ .Values.postgres.password }}"


### PR DESCRIPTION
This adds the missing "args" to specify where postgres should load the config from.