### PR TITLE
fix: check for existing postgresql - config

### DIFF
--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "16-3.4-alpine"
 description: PostGIS Helm chart
 name: postgis
-version: 3.0.0
+version: 3.0.1
 icon: https://postgis.net/logos/postgis-logo.png

--- a/charts/postgis/templates/configmap.yaml
+++ b/charts/postgis/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 {{ include "postgis.labels" . | indent 4 }}
   name: {{ include "postgis.fullname" . }}
 data:
-  {{- with .Values.postgres.conf }}
+  {{- if .Values.postgres.conf }}
   postgresql.conf: |-
 {{ .Values.postgres.conf | indent 4 }}
   {{- end }}


### PR DESCRIPTION
See title.

Required, to pass configured string entries to `postgresl.conf` correctly, e.g.

```
postgres:
  conf: |
    jit = off
```

Plz review @terrestris/devs 