### PR TITLE
fix: use internal keycloak url for jwt verification

### DIFF
--- a/charts/shogun-boot/templates/configmap.yaml
+++ b/charts/shogun-boot/templates/configmap.yaml
@@ -115,7 +115,7 @@ data:
           resourceserver:
             jwt:
               issuer-uri: {{ .Values.keycloak.url }}/realms/{{ .Values.keycloak.realm }}
-              jwk-set-uri: {{ .Values.keycloak.url }}/realms/{{ .Values.keycloak.realm }}/protocol/openid-connect/certs
+              jwk-set-uri: http://{{ .Values.keycloak.internalServerUrl }}/auth/realms/{{ .Values.keycloak.realm }}/protocol/openid-connect/certs
       graphql:
         graphiql:
           enabled: {{ .Values.debug.graphiql }}


### PR DESCRIPTION
If the external keycloak host is not reachable from the shogun-boot container it will cause an error while verifying the jwt. The internal address works.