### PR TITLE
feat: introduce optional geofence initialization

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for GeoServer
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 4.0.0
+version: 4.1.0
 appVersion: 2.25.2

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -15,3 +15,6 @@ The following parameters can be configured in (a custom) `values.yaml`:
 * `persistence.size`: Size of pvc (persistent volume claim)
 * `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
 * `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store geoserver data
+* `geofence.enableInitScript`: A flag to control whether a init script for geofence should run or not. default: `false`.
+* `geofence.dataSourceUrl`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.
+* `geofence.env`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.

--- a/charts/geoserver/templates/configmap.yaml
+++ b/charts/geoserver/templates/configmap.yaml
@@ -64,4 +64,20 @@ data:
       eval $CMD
       echo "Successfully installed community modules to '{{ .Values.storage.additionalLibsDir }}'!"
     fi
+  {{- if .Values.geofence.enableInitScript }}
+  init-geofence.sh: |-
+    #!/bin/sh
+    echo "Initialising geofence config in /opt/geoserver_data/geofence/geofence-datasource-ovr.properties"
+    mkdir -p /opt/geoserver_data/geofence
+    cat > /opt/geoserver_data/geofence/geofence-datasource-ovr.properties << EOL
+    geofenceVendorAdapter.databasePlatform=org.hibernatespatial.postgis.PostgisDialect
+    geofenceDataSource.driverClassName=org.postgresql.Driver
+    geofenceDataSource.url={{ .Values.geofence.dataSourceUrl }}
+    geofenceDataSource.username=${GEOFENCE_DB_USER}
+    geofenceDataSource.password=${GEOFENCE_DB_PASSWORD}
+    geofenceEntityManagerFactory.jpaPropertyMap[hibernate.default_schema]=public
+    geofenceEntityManagerFactory.jpaPropertyMap[hibernate.hbm2ddl.auto]=update
+    EOL
+  {{- end}}
+
 {{- end}}

--- a/charts/geoserver/templates/statefulset.yaml
+++ b/charts/geoserver/templates/statefulset.yaml
@@ -25,6 +25,23 @@ spec:
       initContainers:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.geofence.enableInitScript }}
+      {{- if not .Values.initContainers }}
+      initContainers:
+      {{- end }}
+        - name: init-geofence
+          image: docker.terrestris.de/alpine
+          command: [ "/bin/sh","/mnt/init-geofence.sh" ]
+          volumeMounts:
+            - name: init-geofence-volume
+              mountPath: /mnt/
+            - name: datadir
+              mountPath: /opt/geoserver_data
+          env:
+          {{- with .Values.geofence.env }}
+          {{- tpl . $ | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -105,4 +122,12 @@ spec:
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if .Values.geofence.enableInitScript }}
+        - name: init-geofence-volume
+          configMap:
+            name: geoserver-init-configmap
+            items:
+              - key: init-geofence.sh
+                path: init-geofence.sh
         {{- end }}

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -125,6 +125,18 @@ probes:
     periodSeconds: 10
     url: /geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png
 
+geofence:
+  enableInitScript: false
+  dataSourceUrl: jdbc:postgresql://shogun-postgis:5432/geofence
+  env: |
+    - name: GEOFENCE_DB_USER
+      value: shogun
+    - name: GEOFENCE_DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: shogun-postgis-shogun-credentials
+          key: shogun-password
+
 # extraEnv: |
 #   - name: QUERY_LAYER_MAX_FEATURES
 #     value: 100000

--- a/charts/shogun/Chart.yaml
+++ b/charts/shogun/Chart.yaml
@@ -3,14 +3,14 @@ description: A Helm chart for a complete installation of SHOGun
 name: shogun
 type: application
 icon: https://raw.githubusercontent.com/terrestris/shogun/main/shogun-boot/src/main/resources/public/assets/img/shogun_logo.png
-version: 1.2.3
+version: 1.2.4
 dependencies:
   - name: postgis
     version: "3.0.1"
     repository: "https://terrestris.github.io/helm-charts"
     condition: postgis.enabled
   - name: geoserver
-    version: "4.0.0"
+    version: "4.1.0"
     repository: "https://terrestris.github.io/helm-charts"
     condition: geoserver.enabled
   - name: keycloak


### PR DESCRIPTION
This introduces an optional new feature to initialize geofence configuration.

It can be activated by setting `geofence.enableInitScript` to `true`. As the default value for this flag is `false`, for existing deployments that update to the new chart version, nothing should change.