### PR TITLE
feat: introduce gs monitor extension init script

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for GeoServer
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 4.1.0
+version: 4.2.0
 appVersion: 2.25.2

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -18,3 +18,6 @@ The following parameters can be configured in (a custom) `values.yaml`:
 * `geofence.enableInitScript`: A flag to control whether a init script for geofence should run or not. default: `false`.
 * `geofence.dataSourceUrl`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.
 * `geofence.env`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.
+* `monitoring.enableInitScript`: A flag to control whether a init script for the gs monitoring extension should run or not. default: `false`.
+* `monitoring.filterProperties`: The file content of the [filter.properties](https://docs.geoserver.org/stable/en/user/extensions/monitoring/configuration.html) used by the monitoring extension. This will only be used if `monitoring.enableInitScript` is `true`. default: see `values.yaml`
+* `monitoring.monitorProperties`: The file content of the [monitor.properties](https://docs.geoserver.org/stable/en/user/extensions/monitoring/configuration.html) used by the monitoring extension. This will only be used if `monitoring.enableInitScript` is `true`. default: see `values.yaml`

--- a/charts/geoserver/templates/configmap.yaml
+++ b/charts/geoserver/templates/configmap.yaml
@@ -67,9 +67,9 @@ data:
   {{- if .Values.geofence.enableInitScript }}
   init-geofence.sh: |-
     #!/bin/sh
-    echo "Initialising geofence config in /opt/geoserver_data/geofence/geofence-datasource-ovr.properties"
-    mkdir -p /opt/geoserver_data/geofence
-    cat > /opt/geoserver_data/geofence/geofence-datasource-ovr.properties << EOL
+    echo "Initializing geofence config in {{ .Values.storage.dataDir }}/geofence/geofence-datasource-ovr.properties"
+    mkdir -p {{ .Values.storage.dataDir }}/geofence
+    cat > {{ .Values.storage.dataDir }}/geofence/geofence-datasource-ovr.properties << EOL
     geofenceVendorAdapter.databasePlatform=org.hibernatespatial.postgis.PostgisDialect
     geofenceDataSource.driverClassName=org.postgresql.Driver
     geofenceDataSource.url={{ .Values.geofence.dataSourceUrl }}
@@ -78,6 +78,14 @@ data:
     geofenceEntityManagerFactory.jpaPropertyMap[hibernate.default_schema]=public
     geofenceEntityManagerFactory.jpaPropertyMap[hibernate.hbm2ddl.auto]=update
     EOL
+  {{- end}}
+  {{- if .Values.monitoring.enableInitScript }}
+  init-monitoring.sh: |-
+    #!/bin/sh
+    echo "Initializing monitoring config by copying properties files to {{ .Values.storage.dataDir }}/monitoring"
+    mkdir -p {{ .Values.storage.dataDir }}/monitoring && cp /mnt/{filter,monitor}.properties {{ .Values.storage.dataDir }}/monitoring/
+  filter.properties: {{ .Values.monitoring.filterProperties | toYaml | indent 2 }}
+  monitor.properties: {{ .Values.monitoring.monitorProperties | toYaml | indent 2 }}
   {{- end}}
 
 {{- end}}

--- a/charts/geoserver/templates/statefulset.yaml
+++ b/charts/geoserver/templates/statefulset.yaml
@@ -25,10 +25,11 @@ spec:
       initContainers:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.geofence.enableInitScript }}
-      {{- if not .Values.initContainers }}
+      {{- if and (not .Values.initContainers) (or (.Values.geofence.enableInitScript) (.Values.monitoring.enableInitScript)) }}
+      # only add this if we do not have initContainers, but at least one extension init script
       initContainers:
       {{- end }}
+      {{- if .Values.geofence.enableInitScript }}
         - name: init-geofence
           image: docker.terrestris.de/alpine
           command: [ "/bin/sh","/mnt/init-geofence.sh" ]
@@ -36,11 +37,21 @@ spec:
             - name: init-geofence-volume
               mountPath: /mnt/
             - name: datadir
-              mountPath: /opt/geoserver_data
+              mountPath: {{ .Values.storage.dataDir }}
           env:
           {{- with .Values.geofence.env }}
           {{- tpl . $ | nindent 12 }}
           {{- end }}
+      {{- end }}
+      {{- if .Values.monitoring.enableInitScript }}
+        - name: init-monitoring
+          image: docker.terrestris.de/alpine
+          command: [ "/bin/sh","/mnt/init-monitoring.sh" ]
+          volumeMounts:
+            - name: init-monitoring-volume
+              mountPath: /mnt/
+            - name: datadir
+              mountPath: {{ .Values.storage.dataDir }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -130,4 +141,16 @@ spec:
             items:
               - key: init-geofence.sh
                 path: init-geofence.sh
+        {{- end }}
+        {{- if .Values.monitoring.enableInitScript }}
+        - name: init-monitoring-volume
+          configMap:
+            name: geoserver-init-configmap
+            items:
+              - key: init-monitoring.sh
+                path: init-monitoring.sh
+              - key: filter.properties
+                path: filter.properties
+              - key: monitor.properties
+                path: monitor.properties
         {{- end }}

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -137,6 +137,21 @@ geofence:
           name: shogun-postgis-shogun-credentials
           key: shogun-password
 
+monitoring:
+  enableInitScript: false
+  filterProperties: |-
+    /rest/monitor/**
+    /web
+    /web/**
+    /pdf/**
+  monitorProperties: |-
+    storage=memory
+    mode=history
+    sync=async
+    maxBodySize=1024
+    bboxLogCrs=EPSG:4326
+    bboxLogLevel=no_wfs
+
 # extraEnv: |
 #   - name: QUERY_LAYER_MAX_FEATURES
 #     value: 100000


### PR DESCRIPTION
Analogous to https://github.com/terrestris/helm-charts/pull/92 this PR adds the optional possibility to run a script to initialize the configuration of a the [GeoServer Monitoring Extension](https://docs.geoserver.org/stable/en/user/extensions/monitoring/configuration.html).

The configuration that should be used for the monitoring extension can be defined in the new properties of the `values.yaml`.

By default, this feature is disabled, so nothing changes for existing deployments in case of a chart update.