### PR TITLE
fix: fixes non-working cp command

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for GeoServer
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 4.2.1
+version: 4.2.2
 appVersion: 2.25.2

--- a/charts/geoserver/templates/configmap.yaml
+++ b/charts/geoserver/templates/configmap.yaml
@@ -83,7 +83,7 @@ data:
   init-monitoring.sh: |-
     #!/bin/sh
     echo "Initializing monitoring config by copying properties files to {{ .Values.storage.dataDir }}/monitoring"
-    mkdir -p {{ .Values.storage.dataDir }}/monitoring && cp /mnt/{filter,monitor}.properties {{ .Values.storage.dataDir }}/monitoring/
+    mkdir -p {{ .Values.storage.dataDir }}/monitoring && cp /mnt/*.properties {{ .Values.storage.dataDir }}/monitoring/
   filter.properties: {{ .Values.monitoring.filterProperties | toYaml | indent 2 }}
   monitor.properties: {{ .Values.monitoring.monitorProperties | toYaml | indent 2 }}
   {{- end}}


### PR DESCRIPTION
For some reason `cp /path/{file1,file2}.txt /target/` does not work in the init container (seems that internally some symlink magic is used that might be a problem here)

This change fixes the problem