### PR TITLE
feat: update geoserver ingress

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for GeoServer
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 4.2.2
-appVersion: 2.25.2
+version: 5.0.0
+appVersion: 2.26.0

--- a/charts/geoserver/templates/ingress.yaml
+++ b/charts/geoserver/templates/ingress.yaml
@@ -1,39 +1,43 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "geoserver.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ include "geoserver.fullname" . }}
   labels:
-{{ include "geoserver.labels" . | indent 4 }}
+    {{- include "geoserver.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+    {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ . }}
-            pathType: ImplementationSpecific
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ include "geoserver.fullname" $ }}
                 port:
-                  name: http
-        {{- end }}
-  {{- end }}
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -15,13 +15,15 @@ service:
 
 ingress:
   enabled: false
+  className: "nginx"
   annotations:
-    spec.ingressClassName: nginx
     # kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
   hosts:
     - host: geoserver.example.com
-      paths: [ "/" ]
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls:
     - secretName: geoserver-secret
       hosts:


### PR DESCRIPTION
This updates the geoserver ingress definition to the latest "best practice" version.

The new `ingress.yaml` is based on the content of the `ingress.yaml` created by "helm create geoserver" (in a separate tmp dir).
The `values.yaml` has been adjusted to fit the new structure.