### PR TITLE
feat: create geofence db in case it does not yet exist

### DIFF
--- a/charts/geoserver/Chart.yaml
+++ b/charts/geoserver/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: geoserver
 description: Helm chart for GeoServer
 icon: https://geoserver.org/img/uploads/geoserver_icon.png
-version: 5.0.0
+version: 6.0.0
 appVersion: 2.26.0

--- a/charts/geoserver/README.md
+++ b/charts/geoserver/README.md
@@ -16,7 +16,9 @@ The following parameters can be configured in (a custom) `values.yaml`:
 * `persistence.useExisting`: Should an existing pvc (persistent volume claim) be used, default: `false`
 * `persistence.existingPvcName`: The name of an existing pvc (persistent volume claim) that should be used to store geoserver data
 * `geofence.enableInitScript`: A flag to control whether a init script for geofence should run or not. default: `false`.
-* `geofence.dataSourceUrl`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.
+* `geofence.databaseHost`: This will only be used if `geofence.enableInitScript` is `true`. The host of a postgis database. default: `shogun-postgis`
+* `geofence.databasePort`: This will only be used if `geofence.enableInitScript` is `true`. The port of a postgis database. default: `5432`
+* `geofence.databaseName`: This will only be used if `geofence.enableInitScript` is `true`. The name of the database in the postgis database. default: `geofence`
 * `geofence.env`: This will only be used if `geofence.enableInitScript` is `true`. Have a look at the `values.yaml` for an example value.
 * `monitoring.enableInitScript`: A flag to control whether a init script for the gs monitoring extension should run or not. default: `false`.
 * `monitoring.filterProperties`: The file content of the [filter.properties](https://docs.geoserver.org/stable/en/user/extensions/monitoring/configuration.html) used by the monitoring extension. This will only be used if `monitoring.enableInitScript` is `true`. default: see `values.yaml`

--- a/charts/geoserver/templates/configmap.yaml
+++ b/charts/geoserver/templates/configmap.yaml
@@ -72,12 +72,16 @@ data:
     cat > {{ .Values.storage.dataDir }}/geofence/geofence-datasource-ovr.properties << EOL
     geofenceVendorAdapter.databasePlatform=org.hibernatespatial.postgis.PostgisDialect
     geofenceDataSource.driverClassName=org.postgresql.Driver
-    geofenceDataSource.url={{ .Values.geofence.dataSourceUrl }}
+    geofenceDataSource.url=jdbc:postgresql://{{ .Values.geofence.databaseHost }}:{{ .Values.geofence.databasePort }}/{{ .Values.geofence.databaseName }}
     geofenceDataSource.username=${GEOFENCE_DB_USER}
     geofenceDataSource.password=${GEOFENCE_DB_PASSWORD}
     geofenceEntityManagerFactory.jpaPropertyMap[hibernate.default_schema]=public
     geofenceEntityManagerFactory.jpaPropertyMap[hibernate.hbm2ddl.auto]=update
     EOL
+    until pg_isready -h '{{ .Values.geofence.databaseHost }}' -p {{ .Values.geofence.databasePort }};
+            do echo waiting for database; sleep 2; done;
+    echo "Creating geofence database now (if it does not yet exist)"
+    echo "SELECT 'CREATE DATABASE {{ .Values.geofence.databaseName }}' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{{ .Values.geofence.databaseName }}')\gexec" | PGPASSWORD="${GEOFENCE_DB_PASSWORD}" psql -h '{{ .Values.geofence.databaseHost }}' -p {{ .Values.geofence.databasePort }} -U ${GEOFENCE_DB_USER}
   {{- end}}
   {{- if .Values.monitoring.enableInitScript }}
   init-monitoring.sh: |-

--- a/charts/geoserver/templates/statefulset.yaml
+++ b/charts/geoserver/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       {{- if .Values.geofence.enableInitScript }}
         - name: init-geofence
-          image: docker.terrestris.de/alpine
+          image: docker.terrestris.de/postgis/postgis:16-3.4-alpine
           command: [ "/bin/sh","/mnt/init-geofence.sh" ]
           volumeMounts:
             - name: init-geofence-volume

--- a/charts/geoserver/values.yaml
+++ b/charts/geoserver/values.yaml
@@ -129,7 +129,9 @@ probes:
 
 geofence:
   enableInitScript: false
-  dataSourceUrl: jdbc:postgresql://shogun-postgis:5432/geofence
+  databaseHost: shogun-postgis
+  databasePort: 5432
+  databaseName: geofence
   env: |
     - name: GEOFENCE_DB_USER
       value: shogun


### PR DESCRIPTION
We configure the `geofence-datasource-ovr.properties`, but we do not care yet about the existence of the underlying db...